### PR TITLE
Add resources as input directory to PDF

### DIFF
--- a/build-concourse/step-definitions.ts
+++ b/build-concourse/step-definitions.ts
@@ -59,7 +59,7 @@ set({name: 'git-validate-xhtml-mathified', inputs: [IO.BOOK, IO.MATHIFIED], outp
 set({name: 'git-link', inputs: [IO.BOOK, IO.BAKED, IO.BAKE_META], outputs: [IO.LINKED], env: {ARG_OPT_ONLY_ONE_BOOK: false}})
 set({name: 'git-mathify', inputs: [IO.BOOK, IO.LINKED, IO.BAKED], outputs: [IO.MATHIFIED], env: {ARG_OPT_ONLY_ONE_BOOK: false}})
 set({name: 'git-link-rex', inputs: [IO.BOOK, IO.MATHIFIED, IO.FETCHED], outputs: [IO.REX_LINKED], env: {ARG_OPT_ONLY_ONE_BOOK: false}})
-set({name: 'git-pdfify', inputs: [IO.BOOK, IO.REX_LINKED], outputs: [IO.ARTIFACTS], env: {ARG_OPT_ONLY_ONE_BOOK: false}})
+set({name: 'git-pdfify', inputs: [IO.BOOK, IO.REX_LINKED, IO.RESOURCES], outputs: [IO.ARTIFACTS], env: {ARG_OPT_ONLY_ONE_BOOK: false}})
 set({name: 'git-pdfify-meta', inputs: [IO.BOOK, IO.ARTIFACTS], outputs: [IO.ARTIFACTS], env: {CORGI_ARTIFACTS_S3_BUCKET: true}})
 
 // GIT_WEB_STEPS

--- a/step-config.json
+++ b/step-config.json
@@ -253,7 +253,8 @@
         "git-pdfify": {
             "inputDirs": [
                 "IO_BOOK",
-                "IO_REX_LINKED"
+                "IO_REX_LINKED",
+                "IO_RESOURCES"
             ],
             "outputDirs": [
                 "IO_ARTIFACTS"


### PR DESCRIPTION
Resources were empty in concourse because it was not specified as an input to the git-pdf step.

The broken [git-pdfify step](https://concourse-v7.openstax.org/teams/CE/pipelines/corgi-staging/jobs/PDF%20(git)/builds/59#L6112c8a9:179):

```
prince: loading image: resources/56c7b5a4cbf3329a608284ec89fae72c9f19e664
prince: resources/56c7b5a4cbf3329a608284ec89fae72c9f19e664: warning: can't open input file: No such file or directory
prince: loading image: resources/afc1495a68d2b9bf2df6068d2a0e42dd5c9ca6b1
prince: resources/afc1495a68d2b9bf2df6068d2a0e42dd5c9ca6b1: warning: can't open input file: No such file or directory
prince: loading image: resources/fe5751e479a8db23cd6f731eda8645d9ae88e4de
prince: resources/fe5751e479a8db23cd6f731eda8645d9ae88e4de: warning: can't open input file: No such file or directory
prince: loading image: resources/78b0e1f796574cd72b0bb47d44ea324f510b3daa
```