### PR TITLE
BUG: Rename corgi-prod to use archive-preview

### DIFF
--- a/build-concourse/env/corgi-production.json
+++ b/build-concourse/env/corgi-production.json
@@ -3,7 +3,7 @@
   "CORGI_API_URL": "https://corgi.openstax.org/api",
   "CORGI_ARTIFACTS_S3_BUCKET": "openstax-cops-artifacts",
   "CORGI_CLOUDFRONT_URL": "https://openstax.org",
-  "PREVIEW_APP_URL_PREFIX": "apps/archive",
+  "PREVIEW_APP_URL_PREFIX": "apps/archive-preview",
   "AWS_ACCESS_KEY_ID": "((prod-cops-artifacts-access-key-id))",
   "AWS_SECRET_ACCESS_KEY": "((prod-cops-artifacts-secret-access-key))",
   "GH_SECRET_CREDS": "git:((github-api-token))",


### PR DESCRIPTION
Old CORGI prod generated URLs with `/apps/archive-preview/` and richb-press incorrectly pointed to `/apps/archive/`.

This fixes that bug