### PR TITLE
Fix sandbox webhosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ ENV GEM_PATH=/usr/local/rvm/gems/ruby-${RUBY_VERSION}:/usr/local/rvm/gems/ruby-$
 
 # Use this so that gitpod directories are the same.
 # TODO: Maybe this ENV should be set in a gitpod-specific Dockerfile (if that's possible)
-ENV PROJECT_ROOT=/workspace/book-pipeline
+ENV PROJECT_ROOT=/workspace/richb-press
 
 
 # ---------------------------

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -110,7 +110,7 @@ ENV GEM_PATH=/usr/local/rvm/gems/ruby-${RUBY_VERSION}:/usr/local/rvm/gems/ruby-$
 
 # Use this so that gitpod directories are the same.
 # TODO: Maybe this ENV should be set in a gitpod-specific Dockerfile (if that's possible)
-ENV PROJECT_ROOT=/workspace/book-pipeline
+ENV PROJECT_ROOT=/workspace/richb-press
 
 
 # ---------------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-[![Codecov](https://img.shields.io/codecov/c/github/openstax/book-pipeline)](https://app.codecov.io/gh/openstax/book-pipeline) [![Gitpod](https://img.shields.io/badge/gitpod-ready%20to%20code-lightgrey)](https://gitpod.io/#https://github.com/openstax/book-pipeline)
+[![Codecov](https://img.shields.io/codecov/c/github/openstax/richb-press)](https://app.codecov.io/gh/openstax/richb-press) [![Gitpod](https://img.shields.io/badge/gitpod-ready%20to%20code-lightgrey)](https://gitpod.io/#https://github.com/openstax/richb-press)
 
 We build books in a pipeline of steps. These steps are written in different languages and need to run on a server as well as locally for development.
 
@@ -224,7 +224,7 @@ This repo can be used as the image in a gitpod environment. All of code to build
 - [x] add google docs pipeline-generation
 - [x] auto-build a dependency graph image for documentation [./build-concourse/graphs/](./build-concourse/graphs/)
 - [x] auto-build the bash script
-- [x] wire up codecov.io ([Example](https://codecov.io/gh/openstax/book-pipeline/src/85ee2ea16a401ca07067af699350157b29bdc763/dockerfiles/docker-entrypoint.sh))
+- [x] wire up codecov.io ([Example](https://codecov.io/gh/openstax/richb-press/src/85ee2ea16a401ca07067af699350157b29bdc763/dockerfiles/docker-entrypoint.sh))
 - [x] move all the steps into a JSON file so it can be parsed in node and bash
 - [x] move the bash code for each step into a separate bash file and ensure codecov checks it
 - [x] make the docker-entrypoint script use the JSON file to validate inputs, environment variables, and run the correct step

--- a/build-concourse/README.md
+++ b/build-concourse/README.md
@@ -33,7 +33,7 @@ Now you can build a pipeline using `npm run build` and upload it to concourse.
 
 # Pipeline.yml Build Alternatives
 
-If you are changing code inside the docker image you will need to upload the image to a local registry (see **Option B**). If you are not editing code inside the image then you can use the [main tag on dockerhub](https://hub.docker.com/r/openstax/book-pipeline/tags) by following the instructions in **Option A**.
+If you are changing code inside the docker image you will need to upload the image to a local registry (see **Option B**). If you are not editing code inside the image then you can use the [main tag on dockerhub](https://hub.docker.com/r/openstax/richb-press/tags) by following the instructions in **Option A**.
 
 In both cases you will want to set the AWS credentials which will be used to upload to S3 (e.g. `source /path/to/set_aws_creds -r sandbox:full-admin -t ######`).
 
@@ -66,15 +66,15 @@ cd ../ # main repo directory
 
 # Build the Docker image and upload it to local registry
 # Note: Use 'main' because the RANDOM_DEV_CODEVERSION_PREFIX related code assumes this tag name
-export TAG='localhost:5000/openstax/book-pipeline:main' && docker build --tag $TAG . && docker push $TAG
+export TAG='localhost:5000/openstax/richb-press:main' && docker build --tag $TAG . && docker push $TAG
 
 # Verify the image is in the registry:
 # http://localhost:5000/v2/_catalog
-# http://localhost:5000/v2/openstax/book-pipeline/tags/list    : verify that "main" exists
+# http://localhost:5000/v2/openstax/richb-press/tags/list    : verify that "main" exists
 
 # Build the concourse pipeline to point to our local registry
 cd ./build-concourse/
-DOCKER_REPOSITORY='openstax/book-pipeline' DOCKER_REGISTRY_HOST='registry:5000' CODE_VERSION='main' npm run build
+DOCKER_REPOSITORY='openstax/richb-press' DOCKER_REGISTRY_HOST='registry:5000' CODE_VERSION='main' npm run build
 
 # Send the pipeline definition to concourse (next section)
 ```
@@ -247,7 +247,7 @@ CONCOURSE_WORKER_BAGGAGECLAIM_DRIVER: naive
 This usually means the resource is not in the registry. Verify that the resource definition in the pipeline.yml file is correct. If you are using a local registry, you can use these API links to see which images are in the local registry:
 
 - http://localhost:5000/v2/_catalog
-- http://localhost:5000/v2/openstax/book-pipeline/tags/list    : verify that "main" exists
+- http://localhost:5000/v2/openstax/richb-press/tags/list    : verify that "main" exists
 
 ## `failed to create volume`
 

--- a/build-concourse/env/corgi-local.json
+++ b/build-concourse/env/corgi-local.json
@@ -1,6 +1,6 @@
 {
     "SKIP_TORPEDO_TASK": "true",
-    "DOCKER_REPOSITORY": "openstax/book-pipeline",
+    "DOCKER_REPOSITORY": "openstax/richb-press",
     "DOCKER_REGISTRY_HOST": null,
     "CORGI_API_URL_UNUSED_FOR_NOW": "http://backend/api",
     "CORGI_API_URL_ALSO_UNUSED": "https://corgi-staging.openstax.org/api",

--- a/build-concourse/env/corgi-production.json
+++ b/build-concourse/env/corgi-production.json
@@ -1,5 +1,5 @@
 {
-  "DOCKER_REPOSITORY": "openstax/book-pipeline",
+  "DOCKER_REPOSITORY": "openstax/richb-press",
   "CORGI_API_URL": "https://corgi.openstax.org/api",
   "CORGI_ARTIFACTS_S3_BUCKET": "openstax-cops-artifacts",
   "CORGI_CLOUDFRONT_URL": "https://openstax.org",

--- a/build-concourse/env/corgi-staging.json
+++ b/build-concourse/env/corgi-staging.json
@@ -1,5 +1,5 @@
 {
-  "DOCKER_REPOSITORY": "openstax/book-pipeline",
+  "DOCKER_REPOSITORY": "openstax/richb-press",
   "CORGI_API_URL": "https://corgi-staging.openstax.org/api",
   "CORGI_ARTIFACTS_S3_BUCKET": "openstax-sandbox-cops-artifacts",
   "CORGI_CLOUDFRONT_URL": "https://cops.sandbox.openstax.org",

--- a/build-concourse/env/gdocs-local.json
+++ b/build-concourse/env/gdocs-local.json
@@ -1,5 +1,5 @@
 {
-    "DOCKER_REPOSITORY": "openstax/book-pipeline",
+    "DOCKER_REPOSITORY": "openstax/richb-press",
     "MAX_INFLIGHT_JOBS": 1,
     "WEB_FEED_FILE_URL": "https://raw.githubusercontent.com/openstax/content-manager-approved-books/master/approved-book-list.json",
     "WEB_QUEUE_STATE_S3_BUCKET": "openstax-sandbox-gdocs-queue-state",

--- a/build-concourse/env/gdocs-production.json
+++ b/build-concourse/env/gdocs-production.json
@@ -1,5 +1,5 @@
 {
-    "DOCKER_REPOSITORY": "openstax/book-pipeline",
+    "DOCKER_REPOSITORY": "openstax/richb-press",
     "MAX_INFLIGHT_JOBS": 5,
     "AWS_ACCESS_KEY_ID": "((prod-web-hosting-content-gatekeeper-access-key-id))",
     "AWS_SECRET_ACCESS_KEY": "((prod-web-hosting-content-gatekeeper-secret-access-key))",

--- a/build-concourse/env/webhosting-local.json
+++ b/build-concourse/env/webhosting-local.json
@@ -1,5 +1,5 @@
 {
-    "DOCKER_REPOSITORY": "openstax/book-pipeline",
+    "DOCKER_REPOSITORY": "openstax/richb-press",
     "MAX_INFLIGHT_JOBS": 1,
     "WEB_FEED_FILE_URL": "https://raw.githubusercontent.com/openstax/content-manager-approved-books/master/approved-book-list.json",
     "WEB_S3_BUCKET": "openstax-sandbox-web-hosting-content-gatekeeper",

--- a/build-concourse/env/webhosting-production.json
+++ b/build-concourse/env/webhosting-production.json
@@ -1,5 +1,5 @@
 {
-    "DOCKER_REPOSITORY": "openstax/book-pipeline",
+    "DOCKER_REPOSITORY": "openstax/richb-press",
     "MAX_INFLIGHT_JOBS": 5,
     "AWS_ACCESS_KEY_ID": "((prod-web-hosting-content-gatekeeper-access-key-id))",
     "AWS_SECRET_ACCESS_KEY": "((prod-web-hosting-content-gatekeeper-secret-access-key))",

--- a/build-concourse/env/webhosting-sandbox.json
+++ b/build-concourse/env/webhosting-sandbox.json
@@ -1,8 +1,8 @@
 {
     "DOCKER_REPOSITORY": "openstax/richb-press",
     "MAX_INFLIGHT_JOBS": 5,
-    "AWS_SECRET_ACCESS_KEY": "((aws-sandbox-secret-key-id))",
-    "AWS_ACCESS_KEY_ID": "((aws-sandbox-secret-access-key))",
+    "AWS_SECRET_ACCESS_KEY": "((aws-sandbox-secret-access-key))",
+    "AWS_ACCESS_KEY_ID": "((aws-sandbox-secret-key-id))",
     "WEB_FEED_FILE_URL": "https://raw.githubusercontent.com/openstax/content-manager-approved-books/master/approved-book-list.json",
     "WEB_S3_BUCKET": "openstax-sandbox-web-hosting-content-gatekeeper",
     "WEB_QUEUE_STATE_S3_BUCKET": "openstax-sandbox-web-hosting-content-queue-state",

--- a/build-concourse/env/webhosting-sandbox.json
+++ b/build-concourse/env/webhosting-sandbox.json
@@ -1,5 +1,5 @@
 {
-    "DOCKER_REPOSITORY": "openstax/book-pipeline",
+    "DOCKER_REPOSITORY": "openstax/richb-press",
     "MAX_INFLIGHT_JOBS": 5,
     "AWS_SECRET_ACCESS_KEY": "((aws-sandbox-secret-key-id))",
     "AWS_ACCESS_KEY_ID": "((aws-sandbox-secret-access-key))",

--- a/google-docs.md
+++ b/google-docs.md
@@ -1,6 +1,6 @@
 # Development Steps
 
-To upload to Google Docs in development you can follow these steps. We will need to obtain Google API credentials (`GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`) and a Google Docs Folder (`GDOC_GOOGLE_FOLDER_ID`) to upload to. We will use these 2 environment variables with https://github.com/openstax/book-pipeline to generate DOCX files and then upload them to Google.
+To upload to Google Docs in development you can follow these steps. We will need to obtain Google API credentials (`GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`) and a Google Docs Folder (`GDOC_GOOGLE_FOLDER_ID`) to upload to. We will use these 2 environment variables to generate DOCX files and then upload them to Google.
 
 ## Obtain GOOGLE_SERVICE_ACCOUNT_CREDENTIALS
 
@@ -40,15 +40,15 @@ In https://drive.google.com create a new Folder (e.g. “Test GDocs Root” ) an
 
 ## Build some DOCX files
 
-Use the book-pipeline CLI to generate DOCX files for a book. For example: (the exact syntax is subject to change):
+Use the [CLI](./cli.sh) to generate DOCX files for a book. For example: (the exact syntax is subject to change):
 
 ```sh
-./cli.js ./data/socio all-archive-gdoc col11762 sociology latest
+./cli.sh ./data/socio all-archive-gdoc col11762 sociology latest
 ```
 
 ## Upload the DOCX files to Google Drive
 
-Run the following (from https://github.com/openstax/book-pipeline) to Upload to Google Drive:
+Run the following to Upload to Google Drive:
 
 ```sh
 GDOC_GOOGLE_FOLDER_ID='kqj24h9s8fsdfh_98324hkajehr' \


### PR DESCRIPTION
There were 2 problems encountered:

1. The docker registry image is now `richb-press` instead of book-pipeline so this replaces all references
2. The AWS credentials were flipped for the sandbox webhosting pipeline