### PR TITLE
upload subdirectories inside /resources/

### DIFF
--- a/build-concourse/env/corgi-local.json
+++ b/build-concourse/env/corgi-local.json
@@ -5,7 +5,7 @@
     "CORGI_API_URL_UNUSED_FOR_NOW": "http://backend/api",
     "CORGI_API_URL_ALSO_UNUSED": "https://corgi-staging.openstax.org/api",
     "CORGI_API_URL": "http://smocker:8080/api",
-    "CORGI_ARTIFACTS_S3_BUCKET": "ce-phil",
+    "CORGI_ARTIFACTS_S3_BUCKET": "openstax-sandbox-cops-artifacts",
     "CORGI_CLOUDFRONT_URL": "https://gibberish",
     "PREVIEW_APP_URL_PREFIX": "apps/archive-localdev"
 }

--- a/build-concourse/step-definitions.ts
+++ b/build-concourse/step-definitions.ts
@@ -68,7 +68,7 @@ set({name: 'git-disassemble', inputs: [IO.BOOK, IO.LINKED, IO.BAKE_META], output
 set({name: 'git-patch-disassembled-links', inputs: [IO.BOOK, IO.DISASSEMBLED], outputs: [IO.DISASSEMBLE_LINKED], env: {ARG_OPT_ONLY_ONE_BOOK: false}})
 set({name: 'git-jsonify', inputs: [IO.BOOK, IO.DISASSEMBLE_LINKED], outputs: [IO.JSONIFIED], env: {ARG_OPT_ONLY_ONE_BOOK: false}})
 set({name: 'git-validate-xhtml-jsonify', inputs: [IO.BOOK, IO.JSONIFIED], outputs: [], env: {}})
-set({name: 'git-upload-book', inputs: [IO.BOOK, IO.JSONIFIED, IO.RESOURCES], outputs: [IO.ARTIFACTS], env: {CORGI_ARTIFACTS_S3_BUCKET: true, PREVIEW_APP_URL_PREFIX: true, AWS_ACCESS_KEY_ID: true, AWS_SECRET_ACCESS_KEY: true, AWS_SESSION_TOKEN: false}})
+set({name: 'git-upload-book', inputs: [IO.BOOK, IO.JSONIFIED, IO.RESOURCES], outputs: [IO.ARTIFACTS], env: {CODE_VERSION: true, CORGI_ARTIFACTS_S3_BUCKET: true, PREVIEW_APP_URL_PREFIX: true, AWS_ACCESS_KEY_ID: true, AWS_SECRET_ACCESS_KEY: true, AWS_SESSION_TOKEN: false}})
 
 // ARCHIVE_PDF_STEPS
 set({name: 'archive-mathify', inputs: [IO.BOOK, IO.ARCHIVE_BOOK], outputs: [IO.ARCHIVE_BOOK], env: {}})

--- a/cli.env
+++ b/cli.env
@@ -1,3 +1,7 @@
+PREVIEW_APP_URL_PREFIX=apps/archive-localdev
+CORGI_ARTIFACTS_S3_BUCKET=openstax-sandbox-cops-artifacts
+ARG_S3_BUCKET_NAME=openstax-sandbox-cops-artifacts
+
 INPUT_SOURCE_DIR=_book-input
 
 IO_BOOK=/data/book

--- a/cli.sh
+++ b/cli.sh
@@ -72,6 +72,8 @@ docker run $INTERACTIVE $ENABLE_TTY --volume=$(cd "$local_dir"/; pwd):/data/ \
     --env S3_QUEUE \
     --env GDOC_GOOGLE_FOLDER_ID \
     --env CORGI_ARTIFACTS_S3_BUCKET \
+    --env PREVIEW_APP_URL_PREFIX \
+    --env ARG_S3_BUCKET_NAME \
     --env START_AT_STEP \
     --env STOP_AT_STEP \
     --env KCOV_DIR \

--- a/dockerfiles/steps/git-upload-book.bash
+++ b/dockerfiles/steps/git-upload-book.bash
@@ -15,12 +15,12 @@ try aws s3 cp --recursive "$IO_ARTIFACTS" "s3://$ARG_S3_BUCKET_NAME/$s3_bucket_p
 try copy-resources-s3 "$IO_RESOURCES" "$ARG_S3_BUCKET_NAME" "$s3_bucket_prefix/resources"
 
 # Copy subdirectories (Interactives)
-for dirname in $(ls "$IO_RESOURCES"); do
-    # Ensure dirname is a directory
-    if [[ -d "$IO_RESOURCES/$dirname" ]]; then
-        try aws s3 cp --recursive "$IO_RESOURCES/$dirname" "s3://$ARG_S3_BUCKET_NAME/$s3_bucket_prefix/resources/$dirname"
-    fi
+shopt -s globstar nullglob
+for subdir in "$IO_RESOURCES"/*/; do
+    dirname=$(basename $subdir)
+    try aws s3 cp --recursive "$subdir" "s3://$ARG_S3_BUCKET_NAME/$s3_bucket_prefix/resources/$dirname"
 done
+shopt -u globstar nullglob
 
 #######################################
 # UPLOAD BOOK LEVEL FILES LAST

--- a/dockerfiles/steps/git-upload-book.bash
+++ b/dockerfiles/steps/git-upload-book.bash
@@ -14,6 +14,14 @@ for xhtmlfile in "$IO_JSONIFIED/"*@*.xhtml; do cp "$xhtmlfile" "$IO_ARTIFACTS/$(
 try aws s3 cp --recursive "$IO_ARTIFACTS" "s3://$ARG_S3_BUCKET_NAME/$s3_bucket_prefix/contents"
 try copy-resources-s3 "$IO_RESOURCES" "$ARG_S3_BUCKET_NAME" "$s3_bucket_prefix/resources"
 
+# Copy subdirectories (Interactives)
+for dirname in $(ls "$IO_RESOURCES"); do
+    # Ensure dirname is a directory
+    if [[ -d "$IO_RESOURCES/$dirname" ]]; then
+        try aws s3 cp --recursive "$IO_RESOURCES/$dirname" "s3://$ARG_S3_BUCKET_NAME/$s3_bucket_prefix/resources/$dirname"
+    fi
+done
+
 #######################################
 # UPLOAD BOOK LEVEL FILES LAST
 # so that if an error is encountered

--- a/step-config.json
+++ b/step-config.json
@@ -331,6 +331,7 @@
                 "IO_ARTIFACTS"
             ],
             "requiredEnv": [
+                "CODE_VERSION",
                 "CORGI_ARTIFACTS_S3_BUCKET",
                 "PREVIEW_APP_URL_PREFIX",
                 "AWS_ACCESS_KEY_ID",


### PR DESCRIPTION
We were only uploading book xhtml/json files (using `aws s3 cp --recursive`) and resource files (using `copy-resources-s3`).

This uploads resources/ subdirectories (like interactives)


And s3 autodetects the mimetype (even for TTF font files)

![image](https://user-images.githubusercontent.com/253202/142286155-f3bb22f7-acf4-4b4e-b260-4f4ecbd55fef.png)
![image](https://user-images.githubusercontent.com/253202/142286183-0cafb371-65de-4e87-85bb-788439abff39.png)
