### PR TITLE
build book from a git branch

### DIFF
--- a/test/test-step-03.bash
+++ b/test/test-step-03.bash
@@ -9,3 +9,16 @@ SKIP_DOCKER_BUILD=1 \
 KCOV_DIR=_kcov03 \
 START_AT_STEP=git-disassemble \
 ../cli.sh $BOOK_DIR all-git-web 'philschatz/tiny-book/book-slug1' chemistry main
+
+
+SKIP_DOCKER_BUILD=1 \
+KCOV_DIR=_kcov03 \
+START_AT_STEP=git-disassemble \
+../cli.sh $BOOK_DIR all-git-web 'philschatz/tiny-book/book-slug1' chemistry long-lived-branch-for-testing
+
+
+# Verify we can build a commit that is not on the main branch
+SKIP_DOCKER_BUILD=1 \
+KCOV_DIR=_kcov03 \
+START_AT_STEP=git-disassemble \
+../cli.sh $BOOK_DIR all-git-web 'philschatz/tiny-book/book-slug1' chemistry @458dfb710e9af3d00d6f7e0be45fc819b955d931


### PR DESCRIPTION
This adds support for building books off of a git branch. Since we cannot clone just a commit we try to find the commit with these progressively-larger operations:

1. perform a shallow clone using the 50 most recent commits on the main branch
2. pull the 50 most recent commits on all branches
3. perform a deep clone