### PR TITLE
:bug: fix ABL schema change

### DIFF
--- a/dockerfiles/steps/archive-bake-metadata.bash
+++ b/dockerfiles/steps/archive-bake-metadata.bash
@@ -8,7 +8,7 @@ book_ident_hash="$book_uuid@$book_version"
 book_license="$(cat $book_metadata | jq '.license')"
 target_dir="$IO_ARCHIVE_BOOK"
 book_slugs_file="/tmp/book-slugs.json"
-cat "$IO_ARCHIVE_FETCHED/approved-book-list.json" | jq ".approved_books|map(.books)|flatten" > "$book_slugs_file"
+cat "$IO_ARCHIVE_FETCHED/approved-book-list.json" | jq '[.approved_books[]|select(has("collection_id"))]|map(.books)|flatten' > "$book_slugs_file"
 cat "$IO_ARCHIVE_BOOK/collection.assembled-metadata.json" | \
     jq --arg ident_hash "$book_ident_hash" --arg uuid "$book_uuid" --arg version "$book_version" --argjson license "$book_license" \
     --arg legacy_id "$book_legacy_id" --arg legacy_version "$book_legacy_version" \

--- a/dockerfiles/steps/archive-fetch-metadata.bash
+++ b/dockerfiles/steps/archive-fetch-metadata.bash
@@ -1,2 +1,9 @@
 book_slugs_url='https://raw.githubusercontent.com/openstax/content-manager-approved-books/master/approved-book-list.json'
 try wget "$book_slugs_url" -O "$IO_ARCHIVE_FETCHED/approved-book-list.json"
+
+# Verify the ABL schema version is what subsequent tasks expect
+EXPECTED_ABL_VER=2
+ABL_SCHEMA_VER=$(jq '.api_version' < "$IO_ARCHIVE_FETCHED/approved-book-list.json")
+if [[ $ABL_SCHEMA_VER != "$EXPECTED_ABL_VER" ]]; then
+    die "Subsequent steps assume ABL version $EXPECTED_ABL_VER but the actual is $ABL_SCHEMA_VER" # LCOV_EXCL_LINE
+fi


### PR DESCRIPTION
Baking archive books fails with the new ABL schema change to support git books. 

This change ignores the git entries in the ABL so the intermediate JSON contains pairs of uuid/slug instead of what it does now:

```
[
  null,
  null,
  {uuid: ..., slug: ...},
  {uuid: ..., slug: ...},
  {uuid: ..., slug: ...},
]
```