### PR TITLE
Simulate Concourse directory semantics locally

### DIFF
--- a/cli.env
+++ b/cli.env
@@ -2,6 +2,7 @@ PREVIEW_APP_URL_PREFIX=apps/archive-localdev
 CORGI_ARTIFACTS_S3_BUCKET=openstax-sandbox-cops-artifacts
 ARG_S3_BUCKET_NAME=openstax-sandbox-cops-artifacts
 
+LOCAL_ATTIC_DIR=_attic
 INPUT_SOURCE_DIR=_book-input
 
 ABL_FILE_URL=https://raw.githubusercontent.com/openstax/content-manager-approved-books/master/approved-book-list.json

--- a/cli.sh
+++ b/cli.sh
@@ -82,5 +82,5 @@ docker run $INTERACTIVE $ENABLE_TTY --volume=$(cd "$local_dir"/; pwd):/data/ \
 
 if [[ $2 == *pdf ]]
 then
-    >&2 echo "The PDF is available somewhere in either $local_dir/assembled/collection.pdf or $local_dir/artifacts-single/book.pdf"
+    >&2 echo "The PDF is available near $local_dir/_attic/IO_ARTIFACTS/book.pdf"
 fi

--- a/test/test-step-06.bash
+++ b/test/test-step-06.bash
@@ -5,7 +5,7 @@ set -e
 
 SOCI_DIR=../data/test-soci
 
-xhtml_files_dir="$SOCI_DIR/archive-gdocified/content"
+xhtml_files_dir="$SOCI_DIR/_attic/IO_ARCHIVE_GDOCIFIED/content"
 # shellcheck disable=SC2206
 files=($xhtml_files_dir/*.xhtml)
 keep_file="${files[0]}"


### PR DESCRIPTION
#49 fixed a bug that occurs in concourse but not locally. Locally, directories always exist but in concourse, only directories that are specified in the task as input/output are available. This PR reproduces those semantics but locally. That way the error fixed in #49 will not occur again (because it will be caught locally)

## Concourse Directory semantics:

- [x] only "turn on" directories that are listed in the inputs or outputs section of the [step-config.json](https://github.com/openstax/richb-press/blob/main/step-config.json) file
- [x] ensure changes to an input-only are not seen by later steps
- [x] warn about **all** non-_attic directories before every step

## Implementation approach

To handle the 2 cases above, we create an `_attic/` directory and perform a little housekeeping before and after each step runs:

1. **Before:** copy all [input](https://concourse-ci.org/tutorial-inputs-outputs.html#what-are-inputs-and-outputs) directories from the attic into the workspace
2. **After:** move all [output](https://concourse-ci.org/tutorial-inputs-outputs.html#what-are-inputs-and-outputs) directories from the workspace into the the attic
3. **After:** delete any remaining input directories (extra safety)

<!--

## Nice-to-have
- [ ] ensure input-only dirs are never written to
- [ ] ensure input+output dirs are non-empty beforehand
- [ ] ensure output-only dirs are empty beforehand

-->