### PR TITLE
add dotenv file and ability to mount recipes dir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,27 @@
-export AWS_ACCESS_KEY_ID="((aws-sandbox-secret-key-id))"
-export AWS_SECRET_ACCESS_KEY="((aws-sandbox-secret-access-key))"
-export GH_SECRET_CREDS={{ access_token }}:x-oauth-basic
+# Turn on verbose line-by-line output
+TRACE_ON=1
+
+# Skip time-consuming steps like archive-fetch
+START_AT_STEP=git-bake
+STOP_AT_STEP
+
+# Mount a local recipes from a different directory
+RECIPES_ROOT=./recipes
+
+# Obtain the_token by visiting https://github.com/settings/tokens and ensure the `repo` scope is selected
+# Also, remember to omit the curly-braces in the line below
+GH_SECRET_CREDS={the_token}:x-oauth-basic
+
+# AWS Upload. See `aws-access` repository for how to obtain these values
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+AWS_SESSION_TOKEN
+
+# Google Docs Upload. See ./google-docs.md
+GOOGLE_SERVICE_ACCOUNT_CREDENTIALS
+GDOC_GOOGLE_FOLDER_ID
+
+
+# Docker-related items
+# SKIP_DOCKER_BUILD=1
+CI_TEST=1

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Then try the following to build PDFs and other formats:
 
 ## Private Repositories
 
-To clone private repositories you will need to set `GH_SECRET_CREDS`. To do that, create a token at https://github.com/settings/tokens and ensure the `repo` scope is selected. Then, set `GH_SECRET_CREDS={the_token}:x-oauth-basic` and run the cli.
+To clone private repositories you will need to set `GH_SECRET_CREDS`. To do that, create a token at https://github.com/settings/tokens and ensure the `repo` scope is selected. Then, set `GH_SECRET_CREDS={the_token}:x-oauth-basic` in the `.env` file (see [example](./.env.example) and run the cli.
 
 ## Google Docs
 
@@ -65,33 +65,15 @@ To upload DOCX files to **Google Docs** follow the [instructions here](./google-
 
 # Environment Variables
 
-[dockerfiles/docker-entrypoint.sh](./dockerfiles/docker-entrypoint.sh) specifically makes heavy use of environment variables. It uses them to pass information like which book and version to fetch as well as the directory to read/write to.
+This project uses environment variables extensively to set things like:
 
-When running locally the directories by default read/write to subdirectories of `./data/` using a Docker volume mount. The pipelines that run in concourse use different directories since each one is an input/output directory specified in the Concourse-CI task.
+- Trace Logging
+- Mounting a custom `recipes/` directory
+- Skipping certain steps
+- AWS authentication credentials
+- Google authentication credentials
 
-
-## Common Environment Variables
-
-| Name | Use | Description |
-| :--- | :-- | :---------- |
-| `CODE_VERSION` | | The code version to use when generating the concourse pipeline files
-| `TRACE_ON=1` | Debug | Set to anything to enable trace output
-| `START_AT_STEP` | Dev | Skip time-consuming steps like fetch by setting this
-
-
-## Authentication Secrets
-
-These are only used by some steps and are mostly used for authentication to upload files (except for GH_SECRET_CREDS):
-
-| Name | Use | Description |
-| :--- | :-- | :---------- |
-| `GH_SECRET_CREDS={token}:x-oauth-basic` | Git Clone | GitHub Auth token to clone private repositories. [Create one](https://github.com/settings/tokens) and ensure the `repo` scope is selected.
-| `AWS_ACCESS_KEY_ID` | AWS Upload | See `aws-access` for more
-| `AWS_SECRET_ACCESS_KEY` | AWS Upload | See `aws-access` for more
-| `AWS_SESSION_TOKEN` | AWS Upload | See `aws-access` for more
-| `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS` | Google Docs Upload | See [./google-docs.md](./google-docs.md)
-| `GDOC_GOOGLE_FOLDER_ID` | Google Docs Upload | See [./google-docs.md](./google-docs.md)
-
+See [./.env.example](./.env.example) for all the environment variables and examples.
 
 ## Artifact and Queue Buckets
 
@@ -113,14 +95,6 @@ The pipeline-generation code uses a few additional environment variables:
 | :--- | :-- | :---------- |
 | `DOCKERHUB_USERNAME` | | Your DockerHub username in case you are rate-limited
 | `DOCKERHUB_PASSWORD` | | Your DockerHub password in case you are rate-limited
-
-
-## Internal environment variables
-
-| Name | Use | Description |
-| :--- | :-- | :---------- |
-| `KCOV_DIR` | Test | Name of the subdirectory in `/data/` to write kcov coverage data to |
-| `__CI_KCOV_MERGE_ALL__=1` | Test | Use kcov in the container to merge multiple kcov reports (one for each test) together into one
 
 
 # Features


### PR DESCRIPTION
This hopefully addresses 3 annoyances:

1. it would be useful for style devs to mount a custom recipes directory instead of using the version in this repo submodule.
2. cloning private repos requires setting a `GH_SECRET_CREDS` environment variable which is annoying to specify all the time or annoying to put in a bash profile
2. Remembering all the environment variables is annoying, especially if you just want to rebake a book without re-cloning it all the time

## Features

You can put all the environment variables into a `.env` (aka "dotenv") file in the current directory and the script will read them. This is useful for storing the GH_SECRET_CREDS, TRACE_ON, START_AT_STEP, and other environment variables.

You can set a `RECIPES_ROOT` environment variable to point to your local in-development recipes instead of using the one in this repo.

This PR also introduces another new environment variable (which might be too meta):

- `DOTENV_PATH` specifies which `.env` file to read