### PR TITLE
:bug: branches with '#' in the name

### DIFF
--- a/dockerfiles/steps/git-pdfify-meta.bash
+++ b/dockerfiles/steps/git-pdfify-meta.bash
@@ -1,6 +1,8 @@
 parse_book_dir
 
-pdf_url="https://$ARG_S3_BUCKET_NAME.s3.amazonaws.com/$ARG_TARGET_PDF_FILENAME"
+pdf_filename=$(printf %s "$ARG_TARGET_PDF_FILENAME" | jq -sRr @uri) # URI-encode because book or branch name could have '#'
+pdf_url="https://$ARG_S3_BUCKET_NAME.s3.amazonaws.com/$pdf_filename"
+
 try echo -n "$pdf_url" > "$IO_ARTIFACTS/pdf_url"
 
 echo "DONE: See book at $pdf_url"

--- a/test/test-step-02.bash
+++ b/test/test-step-02.bash
@@ -18,3 +18,23 @@ KCOV_DIR=_kcov02-b \
 SKIP_DOCKER_BUILD=1 \
 KCOV_DIR=_kcov02-c \
 ../cli.sh $BOOK_DIR git-validate-cnxml
+
+
+# ################################
+# Clone a branch, 
+# build the PDF URL,
+# and verify it is URL-encoded
+# ################################
+
+SKIP_DOCKER_BUILD=1 \
+../cli.sh $BOOK_DIR all-git-pdf 'philschatz/tiny-book/book-slug1' default long-lived-branch-for-testing-with-#-char
+
+SKIP_DOCKER_BUILD=1 \
+../cli.sh $BOOK_DIR git-pdfify-meta
+
+expected_pdf_filename='book-slug1-long-lived-branch-for-testing-with-%23-char-git--123456.pdf'
+actual_pdf_url=$(cat $BOOK_DIR/_attic/IO_ARTIFACTS/pdf_url)
+actual_pdf_filename=$(basename "$actual_pdf_url")
+[[ $expected_pdf_filename == $actual_pdf_filename ]] || {
+    echo "PDF URL was not escaped. Expected '$expected_pdf_filename' but got '$actual_pdf_filename'"
+}

--- a/test/test-step-03.bash
+++ b/test/test-step-03.bash
@@ -11,12 +11,6 @@ START_AT_STEP=git-disassemble \
 ../cli.sh $BOOK_DIR all-git-web 'philschatz/tiny-book/book-slug1' chemistry main
 
 
-SKIP_DOCKER_BUILD=1 \
-KCOV_DIR=_kcov03 \
-START_AT_STEP=git-disassemble \
-../cli.sh $BOOK_DIR all-git-web 'philschatz/tiny-book/book-slug1' chemistry long-lived-branch-for-testing
-
-
 # Verify we can build a commit that is not on the main branch
 SKIP_DOCKER_BUILD=1 \
 KCOV_DIR=_kcov03 \


### PR DESCRIPTION
A branch with `#` resulted in a broken URL because the `#` was in the filename and browsers ignore `#` and everything following it when making a request to a webserver.

[Slack Context](https://openstax.slack.com/archives/C0LA54Q5C/p1640017885387700?thread_ts=1639770737.364100&cid=C0LA54Q5C)